### PR TITLE
create submit solution, fix bugs

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,27 +1,21 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"dashboard_header_button": "Dashboard",
-
 	"landing_page_hero_title": "Welcome to the MiNI Testerka!",
 	"landing_page_hero_text_1": "We’re glad to have you here. If you’re interested in becoming a tester, please",
 	"landing_page_hero_text_link": "register here",
 	"landing_page_hero_text_2": "and we’ll to get started.",
-
 	"hi": "Hi",
 	"your_user_id": "Your user id",
 	"view_tasks": "View tasks",
 	"view_users": "View all users",
 	"add_task": "Add new task",
-
 	"username": "Username",
 	"password": "Password",
-
 	"login": "Login",
 	"register": "Register",
 	"logout": "Logout",
-
 	"loading": "Loading",
-
 	"users_table_title": "A list of all registered Users.",
 	"user_id": "User ID",
 	"user_username": "Username",
@@ -29,18 +23,17 @@
 	"user_link": "Profile link",
 	"user_link_text": "See profile",
 	"user_fullname": "Full name",
-
 	"tasks_table_title": "A list of all available Tasks.",
 	"task_id": "Task ID",
 	"task_name": "Task name",
 	"task_link": "Task link",
 	"task_link_text": "View Task",
-
 	"task_form_invalid_type": "Please upload file (.zip)",
 	"task_form_invalid_encoding": "Incorrect file format. Only ZIP format is accepted",
 	"task_form_task_name_label": "Add a new Task",
 	"task_form_task_id_label": "Task ID",
 	"task_form_task_file_label": "Task file",
+	"task_form_task_language_label": "Language of the solution",
 	"task_form_task_file_description": "Please upload a file with the task description.",
 	"task_form_submit": "Submit"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1,27 +1,21 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"dashboard_header_button": "Panel",
-
 	"landing_page_hero_title": "Witamy w MiNI Testerka!",
 	"landing_page_hero_text_1": "Cieszymy się, że jesteś tutaj. Jeśli jesteś zainteresowany/a zostaniem testerem, prosimy",
 	"landing_page_hero_text_link": "zarejestruj się tutaj",
 	"landing_page_hero_text_2": ", abyśmy mogli rozpocząć.",
-
 	"hi": "Cześć",
 	"your_user_id": "Twój identyfikator użytkownika",
 	"view_tasks": "Zobacz zadania",
 	"view_users": "Zobacz wszystkich użytkowników",
 	"add_task": "Dodaj nowe zadanie",
-
 	"username": "Nazwa użytkownika",
 	"password": "Hasło",
-
 	"login": "Zaloguj się",
 	"register": "Zarejestruj się",
 	"logout": "Wyloguj się",
-
 	"loading": "Ładowanie",
-
 	"users_table_title": "Lista wszystkich zarejestrowanych użytkowników.",
 	"user_id": "ID użytkownika",
 	"user_username": "Nazwa użytkownika",
@@ -29,18 +23,17 @@
 	"user_link": "Link do profilu",
 	"user_link_text": "Zobacz profil",
 	"user_fullname": "Imię i nazwisko",
-
 	"tasks_table_title": "Lista wszystkich dostępnych zadań.",
 	"task_id": "ID zadania",
 	"task_name": "Nazwa zadania",
 	"task_link": "Link do zadania",
 	"task_link_text": "Zobacz zadanie",
-
 	"task_form_invalid_type": "Proszę wyślij plik ZIP",
 	"task_form_invalid_encoding": "Nieprawidłowy format pliku. Akceptowany jest tylko format ZIP",
 	"task_form_task_name_label": "Dodaj nowe zadanie",
 	"task_form_task_id_label": "Task ID",
 	"task_form_task_file_label": "Plik zadania",
+	"task_form_task_language_label": "Język zadania",
 	"task_form_task_file_description": "Proszę przesłać plik z opisem zadania.",
 	"task_form_submit": "Wyślij"
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -27,7 +27,7 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 	}
 
 	const responseJson = await response.json();
-	event.locals.userId = responseJson.data.user_id;
+	event.locals.userId = responseJson.data.user.id;
 	event.locals.sessionId = sessionId;
 
 	return resolve(event);

--- a/src/lib/backendSchemas.ts
+++ b/src/lib/backendSchemas.ts
@@ -52,3 +52,10 @@ export interface GetAllUsersResponse {
 		role: string;
 	}[];
 }
+
+export interface LanguageConfig {
+	id: number;
+	language: string;
+	version: string;
+	file_extension: string;
+}

--- a/src/lib/backendSchemas.ts
+++ b/src/lib/backendSchemas.ts
@@ -17,7 +17,7 @@ export interface AuthUserResponse {
 export interface UploadTaskResponse {
 	ok: boolean;
 	data: {
-		taskId: number;
+		id: number;
 	};
 }
 

--- a/src/lib/components/tasks/EditTaskView.svelte
+++ b/src/lib/components/tasks/EditTaskView.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import * as Form from '$lib/components/ui/form';
+	import Label from '$lib/components/ui/label/label.svelte';
+	import { editTaskSchema, type EditTaskSchema } from './formSchema';
+	import { type SuperValidated, type Infer, superForm, fileProxy } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+	import * as m from '$lib/paraglide/messages.js';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import type { LanguageConfig } from '$lib/backendSchemas';
+	import { writable } from 'svelte/store';
+
+	let {
+		data
+	}: {
+		data: {
+			form: SuperValidated<Infer<EditTaskSchema>>;
+			task: { name: string; id: number };
+			availableLanguages: LanguageConfig[];
+		};
+	} = $props();
+
+	const form = superForm(data.form, {
+		validators: zodClient(editTaskSchema),
+		dataType: 'json'
+	});
+
+	const { form: formData, message, enhance } = form;
+	const archive = fileProxy(form, 'archive');
+	$formData.id = data.task.id;
+	$formData.name = data.task.name;
+
+	// Store for selected languages
+	const selectedLanguages = writable<LanguageConfig[]>([]);
+
+	// Handle drag start
+	function handleDragStart(event: DragEvent, lang: LanguageConfig) {
+		event.dataTransfer?.setData('text/plain', JSON.stringify(lang));
+	}
+
+	// Handle drop
+	function handleDrop(event: DragEvent) {
+		event.preventDefault();
+		const langData = event.dataTransfer?.getData('text/plain');
+		if (langData) {
+			const lang: LanguageConfig = JSON.parse(langData);
+			selectedLanguages.update((langs) => {
+				if (!langs.some((l) => l.id === lang.id)) {
+					langs.push(lang);
+				}
+				return langs;
+			});
+			$formData.languages = $selectedLanguages.map((l) => l.id);
+		}
+	}
+
+	// Remove a language
+	function removeLanguage(langId: number) {
+		selectedLanguages.update((langs) => langs.filter((l) => l.id !== langId));
+		$formData.languages = $selectedLanguages.map((l) => l.id);
+	}
+
+	// Prevent default behavior to allow dropping
+	function allowDrop(event: DragEvent) {
+		event.preventDefault();
+	}
+</script>
+
+<form enctype="multipart/form-data" method="POST" use:enhance>
+	<Form.Field {form} name="name">
+		<Form.Control>
+			<Label for="name">Change task name</Label>
+			<Input type="text" id="name" bind:value={$formData.name} placeholder={$formData.name} />
+		</Form.Control>
+		<Form.FieldErrors />
+	</Form.Field>
+	<!-- Language Selection (Drag Source) -->
+	<div class="flex flex-wrap gap-2">
+		{#each data.availableLanguages as lang}
+			<div
+				class="draggable"
+				draggable="true"
+				on:dragstart={(event) => handleDragStart(event, lang)}
+			>
+				{lang.language}
+				{lang.version}
+			</div>
+		{/each}
+	</div>
+
+	<!-- Drop Target -->
+	<div class="dropzone mt-4" on:dragover={allowDrop} on:drop={handleDrop}>
+		{#if $selectedLanguages.length > 0}
+			<ul>
+				{#each $selectedLanguages as lang}
+					<li class="text-green-600">
+						{lang.language}
+						{lang.version}
+						<button type="button" on:click={() => removeLanguage(lang.id)} class="ml-2 text-red-500"
+							>✖</button
+						>
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<span class="text-gray-500">Drop languages here</span>
+		{/if}
+	</div>
+
+	<!-- Hidden field for storing selected languages -->
+	<Form.Field {form} hidden name="languages">
+		<Form.Control>
+			<Input type="text" id="languages" bind:value={$formData.languages} readonly />
+		</Form.Control>
+	</Form.Field>
+
+	<Form.Field {form} name="archive">
+		<Form.Control>
+			<Label for="file">Replace task archive</Label>
+			<input
+				type="file"
+				id="file"
+				class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+				bind:files={$archive}
+			/>
+		</Form.Control>
+		<Form.FieldErrors />
+	</Form.Field>
+
+	<Form.Button class="mt-4">{m.task_form_submit()}</Form.Button>
+	{#if $message}
+		<div class="mt-4 text-red-500">{$message}</div>
+	{/if}
+</form>
+
+<style>
+	.draggable {
+		cursor: grab;
+		background: #f3f3f3;
+		border: 1px solid #ccc;
+		padding: 8px;
+		margin: 4px;
+		border-radius: 4px;
+		display: inline-block;
+	}
+	.dropzone {
+		min-height: 50px;
+		border: 2px dashed #999;
+		padding: 10px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+</style>

--- a/src/lib/components/tasks/TaskView.svelte
+++ b/src/lib/components/tasks/TaskView.svelte
@@ -14,12 +14,14 @@
 				description: Promise<ArrayBuffer>;
 			};
 			uploadSolutionForm: SuperValidated<Infer<UploadTaskSolutionSchema>>;
+			availableLanguages: { id: number; language: string; version: string }[];
 		};
 	} = $props();
 
 	const uploadSolutionData = {
 		form: data.uploadSolutionForm,
-		task_id: data.task.id
+		task_id: data.task.id,
+		availableLanguages: data.availableLanguages
 	};
 </script>
 

--- a/src/lib/components/tasks/formSchema.ts
+++ b/src/lib/components/tasks/formSchema.ts
@@ -95,3 +95,27 @@ function verifyTaskInOut(loadedZip: JSZip, mainFolderPath: string) {
 }
 
 export type CreateTaskSchema = typeof createTaskSchema;
+
+export const editTaskSchema = z.object({
+	id: z.number().int().positive(),
+	name: z.string().min(3).max(50),
+	archive: z
+		.instanceof(File, { message: m.task_form_invalid_type() })
+		.refine((file) => {
+			return file.type === 'application/zip' || file.type === 'application/x-zip-compressed';
+		}, m.task_form_invalid_encoding())
+		.superRefine(async (file, ctx) => {
+			try {
+				await verifyFolderStructure(await file.arrayBuffer());
+			} catch (e: unknown) {
+				if (e instanceof Error) {
+					ctx.addIssue({ code: z.ZodIssueCode.custom, message: e.message });
+				}
+				return false;
+			}
+			return true;
+		}),
+	languages: z.array(z.number().int().positive())
+});
+
+export type EditTaskSchema = typeof editTaskSchema;

--- a/src/lib/components/tasks/solutions/UploadSolution.svelte
+++ b/src/lib/components/tasks/solutions/UploadSolution.svelte
@@ -14,6 +14,7 @@
 		data: {
 			form: SuperValidated<Infer<UploadTaskSolutionSchema>>;
 			task_id: number;
+			availableLanguages: { id: number; language: string; version: string }[];
 		};
 	} = $props();
 
@@ -43,6 +44,25 @@
 			{/snippet}
 		</Form.Control>
 		<Form.Description>{m.task_form_task_file_description()}</Form.Description>
+		<Form.FieldErrors />
+	</Form.Field>
+	<Form.Field {form} name="languageID">
+		<Form.Control>
+			{#snippet children({ props })}
+				<Label for="languageID">{m.task_form_task_language_label()}</Label>
+				<select
+					{...props}
+					id="languageID"
+					class={'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'}
+					bind:value={$formData.languageID}
+				>
+					<option value=""></option>
+					{#each data.availableLanguages as { id, language, version }}
+						<option value={id}>{language} {version}</option>
+					{/each}
+				</select>
+			{/snippet}
+		</Form.Control>
 		<Form.FieldErrors />
 	</Form.Field>
 	<Form.Field {form} hidden name="id">

--- a/src/lib/components/tasks/solutions/UploadSolution.svelte
+++ b/src/lib/components/tasks/solutions/UploadSolution.svelte
@@ -7,6 +7,8 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import { ScrollArea } from '$lib/components/ui/scroll-area/index.js';
 	import Input from '$lib/components/ui/input/input.svelte';
+	import type { LanguageConfig } from '$lib/backendSchemas';
+	import { availableLanguageTags } from '$lib/paraglide/runtime';
 
 	let {
 		data
@@ -14,12 +16,13 @@
 		data: {
 			form: SuperValidated<Infer<UploadTaskSolutionSchema>>;
 			task_id: number;
-			availableLanguages: { id: number; language: string; version: string }[];
+			availableLanguages: LanguageConfig[];
 		};
 	} = $props();
 
 	const form = superForm(data.form, {
-		validators: zodClient(uploadTaskSolutionSchema)
+		validators: zodClient(uploadTaskSolutionSchema),
+		dataType: 'json'
 	});
 
 	const { form: formData, message, errors, enhance } = form;
@@ -46,7 +49,7 @@
 		<Form.Description>{m.task_form_task_file_description()}</Form.Description>
 		<Form.FieldErrors />
 	</Form.Field>
-	<Form.Field {form} name="languageID">
+	<Form.Field {form} name="language">
 		<Form.Control>
 			{#snippet children({ props })}
 				<Label for="languageID">{m.task_form_task_language_label()}</Label>
@@ -54,11 +57,10 @@
 					{...props}
 					id="languageID"
 					class={'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'}
-					bind:value={$formData.languageID}
+					bind:value={$formData.language}
 				>
-					<option value=""></option>
-					{#each data.availableLanguages as { id, language, version }}
-						<option value={id}>{language} {version}</option>
+					{#each data.availableLanguages as lang}
+						<option value={lang}>{lang.language} {lang.version}</option>
 					{/each}
 				</select>
 			{/snippet}

--- a/src/lib/components/tasks/solutions/formSchema.ts
+++ b/src/lib/components/tasks/solutions/formSchema.ts
@@ -12,7 +12,8 @@ export const uploadTaskSolutionSchema = z.object({
 			return (
 				file.type === 'text/plain' || file.type === 'text/x-c++src' || file.type === 'text/x-python'
 			);
-		}, 'File must be a text file')
+		}, 'File must be a text file'),
+	languageID: z.number().int().positive()
 });
 
 export type UploadTaskSolutionSchema = typeof uploadTaskSolutionSchema;

--- a/src/lib/components/tasks/solutions/formSchema.ts
+++ b/src/lib/components/tasks/solutions/formSchema.ts
@@ -1,19 +1,31 @@
 import { z } from 'zod';
 
-export const uploadTaskSolutionSchema = z.object({
-	id: z.number().int().positive(),
-	file: z
-		.instanceof(File)
-		.refine((file) => {
-			const extension = file.name.toLowerCase().split('.').pop();
-			return extension === 'cpp' || extension === 'py';
-		}, 'File must have .cpp or .py extension')
-		.refine((file) => {
-			return (
-				file.type === 'text/plain' || file.type === 'text/x-c++src' || file.type === 'text/x-python'
-			);
-		}, 'File must be a text file'),
-	languageID: z.number().int().positive()
-});
+export const uploadTaskSolutionSchema = z
+	.object({
+		id: z.number().int().positive(),
+		file: z.instanceof(File),
+		language: z.object({ id: z.number().int().positive(), fileExtension: z.string() })
+	})
+	.superRefine((data, ctx) => {
+		const extension = data.file.name.toLowerCase().split('.').pop();
+		if (!data.language) {
+			console.log('Language is not selected');
+			ctx.addIssue({
+				path: ['language'],
+				message: 'Language is not selected',
+				code: 'custom'
+			});
+		}
+		if (data.language.fileExtension !== extension) {
+			console.log('File extension is incorrect');
+			ctx.addIssue({
+				path: ['file'],
+				message: `File extension must be .${data.language.fileExtension}`,
+				code: 'custom'
+			});
+		} else {
+			console.log('File extension is correct');
+		}
+	});
 
 export type UploadTaskSolutionSchema = typeof uploadTaskSolutionSchema;

--- a/src/routes/dashboard/tasks/[taskId]/+page.server.ts
+++ b/src/routes/dashboard/tasks/[taskId]/+page.server.ts
@@ -37,13 +37,24 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		throw error(500, 'Failed to fetch task description');
 	}
 
+	const availavleLanguagesResponse = await fetch(`${env.BACKEND_URL}/api/v1/submission/languages`, {
+		headers: {
+			session: `${locals.sessionId}`
+		}
+	});
+
+	if (!availavleLanguagesResponse.ok) {
+		throw error(500, 'Failed to fetch available languages');
+	}
+
 	return {
 		task: {
 			name: task.data.title,
 			id: task.data.id,
 			description: taskDescriptionResponse.arrayBuffer()
 		},
-		uploadSolutionForm: await superValidate(zod(uploadTaskSolutionSchema))
+		uploadSolutionForm: await superValidate(zod(uploadTaskSolutionSchema)),
+		availableLanguages: (await availavleLanguagesResponse.json()).data
 	};
 };
 
@@ -55,6 +66,42 @@ export const actions: Actions = {
 				form
 			});
 		}
-		// todo: implement solution upload
+
+		const { id, file, languageID } = form.data;
+
+		try {
+			const formData = new FormData();
+			formData.append('taskID', id.toString());
+			formData.append('solution', file);
+			// #TODO add language selection to form
+			formData.append('languageID', languageID.toString());
+
+			const response = await fetch(`${env.BACKEND_URL}/api/v1/submission/submit`, {
+				method: 'POST',
+				body: formData,
+				headers: {
+					session: `${event.locals.sessionId}`
+				}
+			});
+
+			if (!response.ok) {
+				return fail(500, {
+					form,
+					error: 'Failed to submit solution' + response.statusText
+				});
+			}
+
+			return {
+				status: 200,
+				body: {
+					success: true
+				}
+			};
+		} catch (error) {
+			return fail(500, {
+				form,
+				error: 'Failed to submit solution' + error
+			});
+		}
 	}
 };

--- a/src/routes/dashboard/tasks/[taskId]/edit/+page.server.ts
+++ b/src/routes/dashboard/tasks/[taskId]/edit/+page.server.ts
@@ -5,6 +5,7 @@ import { fail, superValidate } from 'sveltekit-superforms';
 import { zod } from 'sveltekit-superforms/adapters';
 import { uploadTaskSolutionSchema } from '$lib/components/tasks/solutions/formSchema';
 import type { GetTaskResponse } from '$lib/backendSchemas';
+import { editTaskSchema } from '$lib/components/tasks/formSchema';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
 	const { taskId } = params;
@@ -53,57 +54,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 			id: task.data.id,
 			description: taskDescriptionResponse.arrayBuffer()
 		},
-		uploadSolutionForm: await superValidate(zod(uploadTaskSolutionSchema)),
+		editTaskForm: await superValidate(zod(editTaskSchema)),
 		availableLanguages: (await availavleLanguagesResponse.json()).data
 	};
-};
-
-export const actions: Actions = {
-	default: async (event) => {
-		console.log(event);
-		const form = await superValidate(event, zod(uploadTaskSolutionSchema));
-		if (!form.valid) {
-			console.log('Form is invalid', form.errors);
-			return fail(400, {
-				form
-			});
-		}
-
-		const { id, file, language } = form.data;
-
-		try {
-			const formData = new FormData();
-			formData.append('taskID', id.toString());
-			formData.append('solution', file);
-			// #TODO add language selection to form
-			formData.append('languageID', language.id.toString());
-
-			const response = await fetch(`${env.BACKEND_URL}/api/v1/submission/submit`, {
-				method: 'POST',
-				body: formData,
-				headers: {
-					session: `${event.locals.sessionId}`
-				}
-			});
-
-			if (!response.ok) {
-				return fail(500, {
-					form,
-					error: 'Failed to submit solution' + response.statusText
-				});
-			}
-
-			return {
-				status: 200,
-				body: {
-					success: true
-				}
-			};
-		} catch (error) {
-			return fail(500, {
-				form,
-				error: 'Failed to submit solution' + error
-			});
-		}
-	}
 };

--- a/src/routes/dashboard/tasks/[taskId]/edit/+page.svelte
+++ b/src/routes/dashboard/tasks/[taskId]/edit/+page.svelte
@@ -2,9 +2,9 @@
 	import UploadTaskSolution from '$lib/components/tasks/solutions/UploadSolution.svelte';
 	import * as m from '$lib/paraglide/messages.js';
 	import type { Infer, SuperValidated } from 'sveltekit-superforms';
-	import { type UploadTaskSolutionSchema } from './solutions/formSchema';
 	import type { LanguageConfig } from '$lib/backendSchemas';
-	import Button from '../ui/button/button.svelte';
+	import { editTaskSchema, type EditTaskSchema } from '$lib/components/tasks/formSchema';
+	import EditTaskView from '$lib/components/tasks/EditTaskView.svelte';
 
 	let {
 		data
@@ -15,36 +15,30 @@
 				id: number;
 				description: Promise<ArrayBuffer>;
 			};
-			uploadSolutionForm: SuperValidated<Infer<UploadTaskSolutionSchema>>;
+			editTaskForm: SuperValidated<Infer<EditTaskSchema>>;
 			availableLanguages: LanguageConfig[];
 		};
 	} = $props();
 
-	const uploadSolutionData = {
-		form: data.uploadSolutionForm,
-		task_id: data.task.id,
+	const editTaskData = {
+		form: data.editTaskForm,
+		task: data.task,
 		availableLanguages: data.availableLanguages
 	};
 </script>
 
-<div class="container mb-12 flex flex-col flex-1">
-	<div class="flex justify-between items-center p-4 items-center">
-		<h1 class="text-2xl font-bold my-4">{data.task.name}</h1>
-		<Button href="/dashboard/tasks/{data.task.id}/edit" class="mb-4">Edit</Button>
-	</div>
-
-	<div class="flex-1 flex overflow-hidden">
-		<div class="w-1/2 p-4 border rounded-sm border-gray-800 overflow-hidden">
+<div class="container mb-12 flex flex-col flex-1 items-center">
+	<div class="flex-1 flex flex-col items-center overflow-hidden">
+		<div class="w-full p-4 overflow-hidden">
+			<EditTaskView data={editTaskData} />
+		</div>
+		<div class="w-full h-[794px] p-4 border rounded-sm border-gray-800">
 			{#await data.task.description}
 				<p class="p-4">{m.loading()}</p>
 			{:then arrayBuffer}
 				{@const pdfUrl = URL.createObjectURL(new Blob([arrayBuffer], { type: 'application/pdf' }))}
 				<iframe src={pdfUrl} title="PDF Viewer" class="w-full h-full"></iframe>
 			{/await}
-		</div>
-
-		<div class="w-1/2 p-4 overflow-hidden">
-			<UploadTaskSolution data={uploadSolutionData} />
 		</div>
 	</div>
 </div>

--- a/src/routes/dashboard/tasks/new/+page.server.ts
+++ b/src/routes/dashboard/tasks/new/+page.server.ts
@@ -2,7 +2,7 @@ import type { PageServerLoad } from './$types.js';
 import { fail, superValidate } from 'sveltekit-superforms';
 import { createTaskSchema } from '$lib/components/tasks/formSchema.js';
 import { zod } from 'sveltekit-superforms/adapters';
-import { redirect, type Actions } from '@sveltejs/kit';
+import { isRedirect, redirect, type Actions } from '@sveltejs/kit';
 import { i18n } from '$lib/i18n.js';
 import { env } from '$env/dynamic/private';
 import type { UploadTaskResponse } from '$lib/backendSchemas.js';
@@ -48,8 +48,11 @@ export const actions: Actions = {
 
 			const responseJson: UploadTaskResponse = await response.json();
 
-			return redirect(303, i18n.resolveRoute(`/dashboard/tasks/${responseJson.data.taskId}`));
+			return redirect(303, i18n.resolveRoute(`/dashboard/tasks/${responseJson.data.id}`));
 		} catch (error) {
+			if (isRedirect(error)) {
+				throw error;
+			}
 			return fail(500, {
 				form,
 				error: 'Failed to create task'


### PR DESCRIPTION
This pull request introduces several changes to the codebase, primarily focusing on adding language selection functionality for task solutions and updating various identifiers. The most important changes include modifications to the form schema, updates to the backend schema, and adjustments to the task solution upload process.

### Language Selection Functionality:
* [`src/lib/components/tasks/solutions/UploadSolution.svelte`](diffhunk://#diff-5016bc0993b7515bb8dfc7167a3f713a5df7715cceba9b38a4b1817d2e554821R49-R67): Added a new form field for selecting the language of the solution.
* [`src/lib/components/tasks/solutions/formSchema.ts`](diffhunk://#diff-1477fcba147eaf13b1edf3f3ff0d9e33c389a5eb19169c64eeb522368214c64eL15-R16): Updated the schema to include a new `languageID` field.
* `src/routes/dashboard/tasks/[taskId]/+page.server.ts`: Added logic to fetch available languages and include them in the task data. ([src/routes/dashboard/tasks/[taskId]/+page.server.tsR40-R57](diffhunk://#diff-382430b2acfcb7cd27d741ca736537dcaf3eb721e503b6750d9572c0a6876a0cR40-R57), [src/routes/dashboard/tasks/[taskId]/+page.server.tsL58-R105](diffhunk://#diff-382430b2acfcb7cd27d741ca736537dcaf3eb721e503b6750d9572c0a6876a0cL58-R105))

### Identifier Updates:
* [`src/hooks.server.ts`](diffhunk://#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4aL30-R30): Changed the assignment of `userId` to use `responseJson.data.user.id` instead of `responseJson.data.user_id`.
* [`src/lib/backendSchemas.ts`](diffhunk://#diff-d82162cd2f7321a00062428cd6bfd04244b6a6bf4f3913118546b05bb46c2801L20-R20): Updated the `UploadTaskResponse` interface to use `id` instead of `taskId`.
* [`src/routes/dashboard/tasks/new/+page.server.ts`](diffhunk://#diff-18e5fea72d0fa98b7b0fb012ca1b087c098a39a09bf1483ee23d14500ddc0b6eL51-R55): Modified the redirect to use the new `id` field in the response.

### Translation Updates:
* `messages/en.json` and `messages/pl.json`: Added a new translation key for the task language label. [[1]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL4-R36) [[2]](diffhunk://#diff-21ebedd5d51c4cdb2ec01182e574d64802318d89672e592edf3b0b1c787324faL4-R36)